### PR TITLE
add a connection timeout option, `connectTimeout`, to tcp driver.

### DIFF
--- a/lib/driver/tcp.js
+++ b/lib/driver/tcp.js
@@ -41,7 +41,10 @@ Driver.connect = function (port, host, options) {
 				return next(null, new stream(transport(socket, options), options));
 			});
 
-			if (options.connectTimeout) {
+			if (typeof options.connectTimeout == "undefined") {
+				options.connectTimeout = 10000; // 10 secs
+			}
+			if (options.connectTimeout > 0) {
 				socket.setTimeout(options.connectTimeout);
 			}
 

--- a/lib/driver/tcp.js
+++ b/lib/driver/tcp.js
@@ -27,13 +27,26 @@ Driver.connect = function (port, host, options) {
 				return next(pdu.Exception.error("GatewayPathUnavailable"));
 			};
 
+			var onTimeout = function () {
+				// destroy here instead of end, otherwise we end up still getting the system's ETIMEDOUT onError
+				socket.destroy();
+				return next(pdu.Exception.error("GatewayPathUnavailable"));
+			};
+
 			var socket = net.connect(port, host, function () {
 				socket.removeListener("error", onError);
+				// remove this listener, otherwise it will also act as an inactivity timeout, not just connecting timeout.
+				socket.removeListener("timeout", onTimeout);
 
 				return next(null, new stream(transport(socket, options), options));
 			});
 
+			if (options.connectTimeout) {
+				socket.setTimeout(options.connectTimeout);
+			}
+
 			socket.on("error", onError);
+			socket.on("timeout", onTimeout);
 
 			return socket;
 		}


### PR DESCRIPTION
I've found that the time to an error occurring seems to be at the mercy of the OS throwing ETIMEOUT when connecting to an IP address where there is no machine. In my case, this takes about 2 minutes. In #2, the option `retry` was suggested to deal with this. In my testing retry seems to apply to individual requests, not to the initial connection.

```bash
[joel@asper server] (develop)$ node -v
v6.11.3
[joel@asper server] (develop)$ node
> const modbus = require('modbus-stream');
undefined
> modbus.tcp.connect(502, '169.254.1.2', {debug:null, retry: 5000}, (e, c) => console.log(new Date(), e, c)); console.log(new Date());
2017-09-15T17:34:39.284Z
undefined
> 2017-09-15T17:36:46.580Z { Error: GatewayPathUnavailable
    at Object.exports.error (/home/joel/WebstormProjects/stream/node_modules/modbus-pdu/lib/Exception.js:24:13)
    at Socket.onError (/home/joel/WebstormProjects/stream/lib/driver/tcp.js:27:31)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1277:8)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9) code: 10 } undefined
> 
```

I've had bad ethernet cables or forgetting to power on the remote modbus device causing issues on a project using modbus-stream. I'd like to get my web front end to have a more timely response to this kind of issue, but there doesn't seem to be a way in modbus-stream for that to happen.

In this pull request, I've added a option `connectTimeout`. This is the maximum amount of milliseconds the user is willing to wait for a connection to be opened. The following is an example issue:

```bash
[joel@asper server] (develop)$ node
> const modbus = require('modbus-stream');
undefined
> modbus.tcp.connect(502, '169.254.1.2', {debug:null, connectTimeout:5000}, (e, c) => console.log(new Date(), e, c)); console.log(new Date());
2017-09-15T17:41:08.955Z
undefined
> 2017-09-15T17:41:13.961Z { Error: GatewayPathUnavailable
    at Object.exports.error (/home/joel/WebstormProjects/stream/node_modules/modbus-pdu/lib/Exception.js:24:13)
    at Socket.onTimeout (/home/joel/WebstormProjects/stream/lib/driver/tcp.js:33:35)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at Socket._onTimeout (net.js:338:8)
    at ontimeout (timers.js:386:11)
    at tryOnTimeout (timers.js:250:5)
    at Timer.listOnTimeout (timers.js:214:5) code: 10 } undefined

> 
```