### PR TITLE
doc: correct syntax contradiction in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is my current `test.js` file. It creates a client and a server network sock
 var modbus = require("modbus-stream");
 
 modbus.tcp.server({ debug: "server" }, (connection) => {
-    connection.readCoils({ from: 3, to: 7 }, (err, info) => {
+    connection.readCoils({ address: 5, quantity: 8 }, (err, info) => {
         console.log("response", info.response.data);
     });
 }).listen(12345, () => {
@@ -92,7 +92,7 @@ modbus.serial.connect("/dev/ttyS123", { debug: "automaton-123" }, (err, connecti
 });
 ```
 
-Every method accepts and object `options` which have defaults parameters (like `address = 0`) and a callback, in case you want to see the response from the remote device. Here is a list of supported function codes and the corresponding methods:
+Every method accepts an object `options` which have defaults parameters (like `address = 0`) and a callback, in case you want to see the response from the remote device. Here is a list of supported function codes and the corresponding methods:
 
 **Base Reads**
 


### PR DESCRIPTION
It looks the call signature for `readCoils` in the first example uses the ([old](https://github.com/dresende/node-modbus-tcp#client-methods)) `{ from: ..., to: ... }` syntax instead of `{ address: ..., quantity: ... }`. I couldn't find the `test.js` file mentioned, but the tests that I did see used the latter syntax (except for the predecessor project [`node-modbus-tcp`](https://github.com/dresende/node-modbus-tcp/blob/master/test/integration/read-coils.js#L27)):

* [`pdu` test for "read coils" operation](https://github.com/node-modbus/pdu/blob/master/test/integration/read-coils.js#L4)
* [`quirks.js`](https://github.com/node-modbus/stream/blob/master/test/integration/quirks.js#L24)